### PR TITLE
Adding static middleware support for windows builds

### DIFF
--- a/middleware/static.ts
+++ b/middleware/static.ts
@@ -4,7 +4,8 @@ export class TrainStatic extends Router {
   constructor(private root: string) {
     super();
     this.get(async (req: Request) => {
-      const joinPath = new URL(this.root + (req.relPath || "/index.html"), window.location.href).pathname;
+      let joinPath = new URL(this.root + (req.relPath || "/index.html"), window.location.href).pathname;
+      joinPath = Deno?.build.os == "win" ? joinPath.substring(1) : joinPath;
       const successful = await req.file(joinPath);
       if (successful)
         return true;


### PR DESCRIPTION
> It might be required to use the --allow-env flag
