### PR TITLE
Supports `_`s in param names and `|`s in values

### DIFF
--- a/src/Router.test.ts
+++ b/src/Router.test.ts
@@ -25,6 +25,7 @@ Deno.test("Router with param matches", async () => {
     "/t/user$1": "user$1",
     "/t/~user1": "~user1",
     "/t/user1!home": "user1!home",
+    "/t/user1|home": "user1|home",
   };
 
   const app = new Application();
@@ -38,6 +39,24 @@ Deno.test("Router with param matches", async () => {
     assertEquals(ctx.res.body, { slug });
   }
 });
+
+Deno.test("Router with \"_\" in param name matches", async () => {
+  const paths = {
+    "/t/user1": "user1",
+  };
+
+  const app = new Application();
+  app.get("/t/:user_slug", (ctx) => {
+    return ctx.req.params;
+  });
+
+  for (const [url, user_slug] of Object.entries(paths)) {
+    const req = generateRequest("GET", url);
+    const ctx = await app.handleRequest(req);
+    assertEquals(ctx.res.body, { user_slug });
+  }
+});
+
 
 Deno.test("Router with no matches", async () => {
   const paths = [

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -199,14 +199,14 @@ export class Router<S extends object = Obj, R extends object = Obj> {
     handler: RequestHandler<S, R>,
   ): HandlerEntry<S, R> {
     if (typeof path == "string") {
-      const paramMatches = path.matchAll(/\/:([a-z]+)/gi);
+      const paramMatches = path.matchAll(/\/:([a-z_]+)/gi);
       const params: string[] = [];
       for (const match of paramMatches) {
         params.push(match[1]);
       }
       path = path
         .replace(/(.)\/$/, "$1")
-        .replace(/\/:([a-z]+)/gi, "/([A-z0-9._~!'()*+,;=:@$-]+)");
+        .replace(/\/:([a-z_]+)/gi, "/([A-z0-9._~|!'()*+,;=:@$-]+)");
       const regex = (handler instanceof Router)
         ? new RegExp(`^${path}`)
         : new RegExp(`^${path}$`);


### PR DESCRIPTION
Allows underscores in param names (e.g. `/t/:my_slug`) and includes `|`
when matching values (`/t/user1|home` would assign `ctx.req.my_slug` to
`user1|home`).